### PR TITLE
feat(docs): add configuration and usage examples for spinner styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,13 @@ processing a request, giving clear feedback to the user.
 
 ![demo](assets/demo.gif)
 
-Note the *"Processing..."* virtual text while AI is generating the response.
+Note the _"Processing..."_ virtual text while AI is generating the response.
 
 ## ✨ Features
 
-- 🌀 Animated spinner in CodeCompanion chat during AI processing.
-- 🗂️ Supports multiple chats with concurrent active requests (each gets its
-  own spinner).
-- ⚙️ Zero configuration.
+own spinner).
+
+- 📊 Fidget.nvim integration for progress notifications (optional).
 
 ## 📦 Installation
 
@@ -31,8 +30,12 @@ Using [lazy.nvim](https://github.com/folke/lazy.nvim):
     dependencies = {
         "olimorris/codecompanion.nvim",
         "nvim-lua/plenary.nvim",
+        "j-hui/fidget.nvim", -- Optional: for fidget integration
     },
-    opts = {}
+     opts = {
+         log_level = "info",
+         style = "spinner", -- "spinner", "fidget", or "none"
+     }
 }
 ```
 
@@ -41,6 +44,26 @@ If you use another plugin manager, make sure to call:
 ```lua
 require("codecompanion-spinner").setup()
 ```
+
+## ⚙️ Configuration
+
+```lua
+require("codecompanion-spinner").setup({
+    -- Log level for debugging
+    log_level = "info", -- "trace", "debug", "info", "warn", "error"
+
+    -- Spinner style
+    style = "spinner", -- "spinner", "fidget", or "none"
+})
+```
+
+The plugin supports different spinner styles:
+
+- **"spinner"** (default): Custom animated spinner in chat buffers
+- **"fidget"**: Uses fidget.nvim for progress notifications (requires fidget.nvim)
+- **"none"**: Disables all spinner functionality
+
+Only one style can be active at a time.
 
 ## 🙏 Acknowledgements
 

--- a/doc/codecompanion-spinner.txt
+++ b/doc/codecompanion-spinner.txt
@@ -6,8 +6,10 @@ Table of Contents                    *codecompanion-spinner-table-of-contents*
 1. Overview                                   |codecompanion-spinner-overview|
 2. Features                                   |codecompanion-spinner-features|
 3. Installation                           |codecompanion-spinner-installation|
-4. Acknowledgements                   |codecompanion-spinner-acknowledgements|
-5. Links                                         |codecompanion-spinner-links|
+4. Configuration                         |codecompanion-spinner-configuration|
+5. Examples                                   |codecompanion-spinner-examples|
+6. Acknowledgements                   |codecompanion-spinner-acknowledgements|
+7. Links                                         |codecompanion-spinner-links|
 
 ==============================================================================
 1. Overview                                   *codecompanion-spinner-overview*
@@ -18,18 +20,19 @@ Inline spinner for CodeCompanion
 This plugin adds an animated spinner in the CodeCompanion chat while AI is
 processing a request, giving clear feedback to the user.
 
-Note the _“Processing…”_ virtual text while AI is generating the
-response.
-
+Note the _"Processing..."_ virtual text while AI is generating the response.
 
 ==============================================================================
 2. Features                                   *codecompanion-spinner-features*
 
-- Animated spinner in CodeCompanion chat during AI processing.
+- Animated spinner in CodeCompanion chat during AI processing
 - Supports multiple chats with concurrent active requests (each gets its
-    own spinner).
-- Zero configuration.
-
+  own spinner)
+- Fidget.nvim integration for progress notifications (optional)
+- Multiple spinner styles: "spinner", "fidget", or "none"
+- Configurable log levels for debugging
+- Zero configuration by default
+- Runtime style switching support
 
 ==============================================================================
 3. Installation                           *codecompanion-spinner-installation*
@@ -39,33 +42,135 @@ Using lazy.nvim <https://github.com/folke/lazy.nvim>
 >lua
     {
         "franco-ruggeri/codecompanion-spinner.nvim",
-        dev = true,
-        lazy = true,
         dependencies = {
             "olimorris/codecompanion.nvim",
             "nvim-lua/plenary.nvim",
+            "j-hui/fidget.nvim", -- Optional: for fidget integration
         },
-        opts = {}
+        opts = {
+            log_level = "info",
+            style = "spinner", -- "spinner", "fidget", or "none"
+        }
     }
 <
 
-Ifyou use another plugin manager, make sure to call:
+If you use another plugin manager, make sure to call:
 
 >lua
     require("codecompanion-spinner").setup()
 <
 
+==============================================================================
+4. Configuration                         *codecompanion-spinner-configuration*
+
+Configure the plugin using the `setup()` function:
+
+>lua
+    require("codecompanion-spinner").setup({
+        -- Log level for debugging
+        log_level = "info", -- "trace", "debug", "info", "warn", "error"
+        
+        -- Spinner style
+        style = "spinner", -- "spinner", "fidget", or "none"
+    })
+<
+
+*codecompanion-spinner-log-level*
+The `log_level` option controls logging verbosity:
+- `"trace"`: Most verbose, shows all debug information
+- `"debug"`: Debug information for troubleshooting
+- `"info"`: General information messages (default)
+- `"warn"`: Warning messages only
+- `"error"`: Error messages only
+
+*codecompanion-spinner-style*
+The `style` option controls which spinner style to use:
+- `"spinner"` (default): Custom animated spinner in chat buffers
+- `"fidget"`: Uses fidget.nvim for progress notifications
+- `"none"`: Disables all spinner functionality
+
+*codecompanion-spinner-style-comparison*
+Spinner Style ("spinner"):
+- ✅ No external dependencies
+- ✅ Integrated directly into chat buffers
+- ✅ Consistent with CodeCompanion UI
+- ❌ Only visible in chat buffers
+
+Fidget Style ("fidget"):
+- ✅ System-wide progress notifications
+- ✅ Consistent with other LSP progress indicators
+- ✅ Shows detailed adapter/model information
+- ❌ Requires fidget.nvim dependency
+
+None Style ("none"):
+- ✅ No visual distractions
+- ✅ Minimal resource usage
+- ❌ No visual feedback for request progress
 
 ==============================================================================
-4. Acknowledgements                   *codecompanion-spinner-acknowledgements*
+5. Examples                                   *codecompanion-spinner-examples*
+
+*codecompanion-spinner-example-default*
+Default configuration:
+>lua
+    require("codecompanion-spinner").setup()
+<
+
+*codecompanion-spinner-example-fidget*
+Fidget integration:
+>lua
+    require("codecompanion-spinner").setup({
+        style = "fidget",
+        log_level = "info",
+    })
+<
+
+*codecompanion-spinner-example-disabled*
+Disabled spinner:
+>lua
+    require("codecompanion-spinner").setup({
+        style = "none",
+        log_level = "warn",
+    })
+<
+
+*codecompanion-spinner-example-dynamic*
+Dynamic configuration based on available plugins:
+>lua
+    local has_fidget = pcall(require, "fidget")
+    require("codecompanion-spinner").setup({
+        style = has_fidget and "fidget" or "spinner",
+        log_level = "info",
+    })
+<
+
+*codecompanion-spinner-runtime-switching*
+Runtime style switching:
+>lua
+    -- Switch to fidget style
+    require("codecompanion-spinner").setup({ style = "fidget" })
+    
+    -- Switch to spinner style
+    require("codecompanion-spinner").setup({ style = "spinner" })
+    
+    -- Disable spinner
+    require("codecompanion-spinner").setup({ style = "none" })
+<
+
+==============================================================================
+6. Acknowledgements                   *codecompanion-spinner-acknowledgements*
 
 Thanks yuhua99 <https://github.com/yuhua99> for providing the spinner logic
 <https://github.com/olimorris/codecompanion.nvim/discussions/640#discussioncomment-12866279>.
 
 ==============================================================================
-5. Links                                         *codecompanion-spinner-links*
+7. Links                                         *codecompanion-spinner-links*
 
 1. *demo*: assets/demo.gif
+2. *configuration guide*: docs/configuration.md
+3. *examples*: examples/
+4. *lazy config*: examples/lazy-config.lua
+5. *different configs*: examples/different-configs.lua
 
 Generated by panvimdoc <https://github.com/kdheepak/panvimdoc>
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,144 @@
+# Configuration Guide
+
+## Overview
+
+codecompanion-spinner.nvim supports different visual feedback styles for CodeCompanion requests. You can choose between custom spinners, fidget integration, or disable the functionality entirely.
+
+## Configuration Options
+
+### `style` (string)
+
+Controls which spinner style to use. Must be one of:
+
+- **`"spinner"`** (default): Custom animated spinner in chat buffers
+- **`"fidget"`**: Uses fidget.nvim for progress notifications  
+- **`"none"`**: Disables all spinner functionality
+
+### `log_level` (string)
+
+Controls logging verbosity. Options:
+
+- `"trace"`: Most verbose, shows all debug information
+- `"debug"`: Debug information for troubleshooting
+- `"info"`: General information messages (default)
+- `"warn"`: Warning messages only
+- `"error"`: Error messages only
+
+## Style Comparison
+
+### Spinner Style (`"spinner"`)
+
+**Pros:**
+- ✅ No external dependencies
+- ✅ Integrated directly into chat buffers
+- ✅ Consistent with CodeCompanion UI
+- ✅ Shows per-chat progress
+
+**Cons:**
+- ❌ Only visible in chat buffers
+- ❌ Less system-wide visibility
+
+**Best for:** Users who prefer minimal dependencies and want spinner feedback directly in the chat interface.
+
+### Fidget Style (`"fidget"`)
+
+**Pros:**
+- ✅ System-wide progress notifications
+- ✅ Consistent with other LSP progress indicators
+- ✅ Shows detailed adapter/model information
+- ✅ Better for background requests
+
+**Cons:**
+- ❌ Requires fidget.nvim dependency
+- ❌ Less integrated with chat UI
+
+**Best for:** Users who already use fidget.nvim for LSP progress and want consistent progress indicators across their setup.
+
+### None Style (`"none"`)
+
+**Pros:**
+- ✅ No visual distractions
+- ✅ Minimal resource usage
+- ✅ Clean interface
+
+**Cons:**
+- ❌ No visual feedback for request progress
+- ❌ Harder to know when requests are active
+
+**Best for:** Users who prefer minimal UI and don't need progress indicators.
+
+## Example Configurations
+
+### Basic Setup (Default)
+```lua
+require("codecompanion-spinner").setup()
+-- Uses default: style = "spinner", log_level = "info"
+```
+
+### Fidget Integration
+```lua
+require("codecompanion-spinner").setup({
+    style = "fidget",
+    log_level = "info",
+})
+```
+
+### Disabled Spinner
+```lua
+require("codecompanion-spinner").setup({
+    style = "none",
+    log_level = "warn", -- Reduce logging when disabled
+})
+```
+
+### Dynamic Configuration
+```lua
+-- Choose style based on available plugins
+local has_fidget = pcall(require, "fidget")
+require("codecompanion-spinner").setup({
+    style = has_fidget and "fidget" or "spinner",
+    log_level = "info",
+})
+```
+
+## Runtime Style Switching
+
+You can change the style at runtime by calling setup again:
+
+```lua
+-- Switch to fidget style
+require("codecompanion-spinner").setup({ style = "fidget" })
+
+-- Switch to spinner style  
+require("codecompanion-spinner").setup({ style = "spinner" })
+
+-- Disable spinner
+require("codecompanion-spinner").setup({ style = "none" })
+```
+
+## Troubleshooting
+
+### Fidget Style Not Working
+
+1. Ensure fidget.nvim is installed and configured
+2. Check that fidget.nvim is loaded before codecompanion-spinner
+3. Enable debug logging: `log_level = "debug"`
+
+### Spinner Not Showing
+
+1. Ensure CodeCompanion is properly configured
+2. Check that the chat buffer is active
+3. Verify that requests are being made to the LLM
+
+### Performance Issues
+
+1. Try switching to `"none"` style to disable all spinners
+2. Reduce log level to `"warn"` or `"error"`
+3. Check if other plugins are conflicting
+
+## Dependencies
+
+- **All styles**: `codecompanion.nvim`, `plenary.nvim`
+- **Fidget style**: Additionally requires `fidget.nvim`
+- **Spinner style**: No additional dependencies
+- **None style**: No additional dependencies

--- a/examples/different-configs.lua
+++ b/examples/different-configs.lua
@@ -1,0 +1,79 @@
+-- Different configuration examples for codecompanion-spinner.nvim
+
+-- Example 1: Default spinner style (recommended)
+local config_spinner = {
+	"franco-ruggeri/codecompanion-spinner.nvim",
+	dependencies = {
+		"olimorris/codecompanion.nvim",
+		"nvim-lua/plenary.nvim",
+	},
+	opts = {
+		log_level = "info",
+		style = "spinner", -- Use custom spinner in chat buffers
+	},
+}
+
+-- Example 2: Fidget integration style
+local config_fidget = {
+	"franco-ruggeri/codecompanion-spinner.nvim",
+	dependencies = {
+		"olimorris/codecompanion.nvim",
+		"nvim-lua/plenary.nvim",
+		"j-hui/fidget.nvim", -- Required for fidget style
+	},
+	opts = {
+		log_level = "info",
+		style = "fidget", -- Use fidget.nvim for progress notifications
+	},
+}
+
+-- Example 3: Disabled spinner
+local config_none = {
+	"franco-ruggeri/codecompanion-spinner.nvim",
+	dependencies = {
+		"olimorris/codecompanion.nvim",
+		"nvim-lua/plenary.nvim",
+	},
+	opts = {
+		log_level = "info",
+		style = "none", -- Disable all spinner functionality
+	},
+}
+
+-- Example 4: Runtime configuration switching
+local config_dynamic = {
+	"franco-ruggeri/codecompanion-spinner.nvim",
+	dependencies = {
+		"olimorris/codecompanion.nvim",
+		"nvim-lua/plenary.nvim",
+		"j-hui/fidget.nvim", -- Optional
+	},
+	config = function()
+		-- Check if fidget is available and configure accordingly
+		local has_fidget = pcall(require, "fidget")
+
+		require("codecompanion-spinner").setup({
+			log_level = "info",
+			style = has_fidget and "fidget" or "spinner",
+		})
+
+		-- Add user commands to switch styles
+		vim.api.nvim_create_user_command("SpinnerStyleSpinner", function()
+			require("codecompanion-spinner").setup({ style = "spinner" })
+			vim.notify("Switched to spinner style")
+		end, {})
+
+		vim.api.nvim_create_user_command("SpinnerStyleFidget", function()
+			require("codecompanion-spinner").setup({ style = "fidget" })
+			vim.notify("Switched to fidget style")
+		end, {})
+
+		vim.api.nvim_create_user_command("SpinnerStyleNone", function()
+			require("codecompanion-spinner").setup({ style = "none" })
+			vim.notify("Disabled spinner")
+		end, {})
+	end,
+}
+
+-- Return the configuration you want to use
+return config_spinner -- or config_fidget, config_none, config_dynamic

--- a/examples/lazy-config.lua
+++ b/examples/lazy-config.lua
@@ -1,0 +1,46 @@
+-- Example configuration for codecompanion-spinner.nvim
+-- Place this in your Neovim configuration
+
+return {
+	-- CodeCompanion plugin with spinner extension
+	{
+		"olimorris/codecompanion.nvim",
+		dependencies = {
+			"nvim-lua/plenary.nvim",
+			"nvim-treesitter/nvim-treesitter",
+			"j-hui/fidget.nvim", -- Optional: for progress notifications
+		},
+		config = function()
+			require("codecompanion").setup({
+				-- Your codecompanion configuration here
+			})
+		end,
+	},
+
+	-- Spinner extension for CodeCompanion
+	{
+		"franco-ruggeri/codecompanion-spinner.nvim",
+		dependencies = {
+			"olimorris/codecompanion.nvim",
+			"nvim-lua/plenary.nvim",
+			"j-hui/fidget.nvim", -- Optional: for fidget integration
+		},
+		config = function()
+			require("codecompanion-spinner").setup({
+				-- Log level for debugging
+				log_level = "info", -- "trace", "debug", "info", "warn", "error"
+
+				-- Spinner style: "spinner" (default), "fidget", or "none"
+				style = "spinner",
+			})
+		end,
+	},
+
+	-- Fidget.nvim for progress notifications (optional)
+	{
+		"j-hui/fidget.nvim",
+		opts = {
+			-- Your fidget configuration here
+		},
+	},
+}

--- a/lua/codecompanion-spinner/fidget-spinner.lua
+++ b/lua/codecompanion-spinner/fidget-spinner.lua
@@ -1,0 +1,153 @@
+local log = require("codecompanion-spinner.log")
+
+local M = {}
+
+function M.setup()
+	-- Check if fidget.nvim is installed
+	local ok, progress = pcall(require, "fidget.progress")
+	if not ok then
+		log.warn("fidget.nvim not found, fidget-spinner functionality disabled")
+		return
+	end
+
+	M.progress = progress
+	M.handles = {}
+
+	-- Check if already initialized
+	if M.initialized then
+		log.debug("fidget-spinner already initialized")
+		return
+	end
+
+	M:init()
+	M.initialized = true
+	log.info("fidget-spinner initialized")
+end
+
+function M:init()
+	local group = vim.api.nvim_create_augroup("CodeCompanionFidgetHooks", {})
+
+	vim.api.nvim_create_autocmd({ "User" }, {
+		pattern = "CodeCompanionRequestStarted",
+		group = group,
+		callback = function(request)
+			log.debug("CodeCompanionRequestStarted - creating progress handle")
+			if not request.data or not request.data.id then
+				log.warn("Invalid request data in CodeCompanionRequestStarted")
+				return
+			end
+			local handle = M:create_progress_handle(request)
+			M:store_progress_handle(request.data.id, handle)
+		end,
+	})
+
+	vim.api.nvim_create_autocmd({ "User" }, {
+		pattern = "CodeCompanionRequestFinished",
+		group = group,
+		callback = function(request)
+			log.debug("CodeCompanionRequestFinished - finishing progress handle")
+			if not request.data or not request.data.id then
+				log.warn("Invalid request data in CodeCompanionRequestFinished")
+				return
+			end
+			local handle = M:pop_progress_handle(request.data.id)
+			if handle then
+				M:report_exit_status(handle, request)
+				handle:finish()
+			end
+		end,
+	})
+end
+
+function M:store_progress_handle(id, handle)
+	if not id or not handle then
+		log.warn("Invalid parameters for store_progress_handle", id, handle)
+		return
+	end
+	M.handles[id] = handle
+	log.debug("Stored progress handle for request", id)
+end
+
+function M:pop_progress_handle(id)
+	if not id then
+		log.warn("Invalid id for pop_progress_handle")
+		return nil
+	end
+	local handle = M.handles[id]
+	M.handles[id] = nil
+	log.debug("Popped progress handle for request", id)
+	return handle
+end
+
+function M:create_progress_handle(request)
+	if not request or not request.data then
+		log.error("Invalid request data for create_progress_handle")
+		return nil
+	end
+
+	local title = " Requesting assistance "
+	if request.data.strategy then
+		title = title .. "(" .. request.data.strategy .. ")"
+	end
+
+	if not M.progress then
+		log.error("Fidget progress not initialized")
+		return nil
+	end
+
+	local handle = M.progress.handle.create({
+		title = title,
+		message = "In progress...",
+		lsp_client = {
+			name = M:llm_role_title(request.data.adapter),
+		},
+	})
+
+	log.debug("Created progress handle with title:", title)
+	return handle
+end
+
+function M:llm_role_title(adapter)
+	if not adapter then
+		return "Unknown"
+	end
+
+	local parts = {}
+	table.insert(parts, adapter.formatted_name or "Unknown")
+	if adapter.model and adapter.model ~= "" then
+		table.insert(parts, "(" .. adapter.model .. ")")
+	end
+	return table.concat(parts, " ")
+end
+
+function M:report_exit_status(handle, request)
+	if not handle or not request or not request.data then
+		log.warn("Invalid parameters for report_exit_status")
+		return
+	end
+
+	if request.data.status == "success" then
+		handle.message = "Completed"
+	elseif request.data.status == "error" then
+		handle.message = " Error"
+	else
+		handle.message = "󰜺 Cancelled"
+	end
+	log.debug("Reported exit status:", request.data.status)
+end
+
+-- Provide cleanup method
+function M.cleanup()
+	if M.handles then
+		for id, handle in pairs(M.handles) do
+			if handle and handle.finish then
+				pcall(handle.finish, handle)
+			end
+		end
+		M.handles = {}
+	end
+	M.initialized = false
+	M.progress = nil
+end
+
+return M

--- a/lua/codecompanion-spinner/init.lua
+++ b/lua/codecompanion-spinner/init.lua
@@ -56,4 +56,23 @@ function M.setup(opts)
 	end
 end
 
+-- Cleanup function to safely stop all spinners
+function M.cleanup()
+	-- Cleanup spinner manager if it was initialized
+	if M.spinner_manager and type(M.spinner_manager.cleanup) == "function" then
+		local ok, err = pcall(M.spinner_manager.cleanup)
+		if not ok then
+			M.log.error("Failed to cleanup spinner manager:", err)
+		end
+	end
+	
+	-- Cleanup fidget spinner if it was initialized
+	if M.fidget_spinner and type(M.fidget_spinner.cleanup) == "function" then
+		local ok, err = pcall(M.fidget_spinner.cleanup)
+		if not ok then
+			M.log.error("Failed to cleanup fidget spinner:", err)
+		end
+	end
+end
+
 return M

--- a/lua/codecompanion-spinner/init.lua
+++ b/lua/codecompanion-spinner/init.lua
@@ -1,16 +1,59 @@
 local M = {}
 
 M.spinner_manager = require("codecompanion-spinner.spinner-manager")
+M.fidget_spinner = require("codecompanion-spinner.fidget-spinner")
 M.log = require("codecompanion-spinner.log")
 
+-- Valid spinner styles
+M.STYLES = {
+	SPINNER = "spinner",
+	FIDGET = "fidget",
+	NONE = "none",
+}
 M.opts = {
 	log_level = "info",
+	style = M.STYLES.SPINNER, -- Default to spinner
 }
+local function validate_style(style)
+	if not style then
+		return false
+	end
+	for _, valid_style in pairs(M.STYLES) do
+		if style == valid_style then
+			return true
+		end
+	end
+	return false
+end
 
 function M.setup(opts)
 	M.opts = vim.tbl_deep_extend("force", M.opts, opts or {})
-	M.spinner_manager.setup()
+
+	-- Ensure logging is initialized first
 	M.log.setup(M.opts.log_level)
+
+	-- Validate style
+	if not validate_style(M.opts.style) then
+		M.log.warn("Invalid style '" .. tostring(M.opts.style) .. "', using default '" .. M.STYLES.SPINNER .. "'")
+		M.opts.style = M.STYLES.SPINNER
+	end
+
+	-- Enable corresponding functionality based on style configuration
+	if M.opts.style == M.STYLES.SPINNER then
+		local ok, err = pcall(M.spinner_manager.setup)
+		if not ok then
+			M.log.error("Failed to setup spinner manager:", err)
+		end
+	elseif M.opts.style == M.STYLES.FIDGET then
+		local ok, err = pcall(M.fidget_spinner.setup)
+		if not ok then
+			M.log.error("Failed to setup fidget spinner:", err)
+		end
+	elseif M.opts.style == M.STYLES.NONE then
+		-- Do not enable any spinner
+		M.log.info("Spinner disabled")
+		return
+	end
 end
 
 return M

--- a/lua/codecompanion-spinner/log.lua
+++ b/lua/codecompanion-spinner/log.lua
@@ -1,12 +1,35 @@
 local M = {}
 
 M.setup = function(log_level)
-	local log = require("plenary.log").new({
+	local ok, plenary_log = pcall(require, "plenary.log")
+	if not ok then
+		-- If plenary is not available, provide a basic logging implementation
+		M.trace = function(...) end
+		M.debug = function(...) end
+		M.info = function(...)
+			print("[INFO]", ...)
+		end
+		M.warn = function(...)
+			print("[WARN]", ...)
+		end
+		M.error = function(...)
+			print("[ERROR]", ...)
+		end
+		return
+	end
+
+	local log = plenary_log.new({
 		plugin = "codecompanion-spinner",
-		level = log_level,
+		level = log_level or "info",
 	})
 
 	setmetatable(M, { __index = log })
 end
 
+-- Provide default empty functions to prevent errors before setup
+M.trace = function(...) end
+M.debug = function(...) end
+M.info = function(...) end
+M.warn = function(...) end
+M.error = function(...) end
 return M

--- a/lua/codecompanion-spinner/spinner-manager.lua
+++ b/lua/codecompanion-spinner/spinner-manager.lua
@@ -11,10 +11,23 @@ M.setup = function()
 		pattern = "CodeCompanionChatCreated",
 		callback = function(args)
 			log.debug("CodeCompanionChatCreated")
+			if not args or not args.data or not args.data.id then
+				log.warn("Invalid args in CodeCompanionChatCreated")
+				return
+			end
+
 			local chat_id = args.data.id
-			assert(spinners[chat_id] == nil)
+			if spinners[chat_id] then
+				log.warn("Spinner already exists for chat", chat_id)
+				spinners[chat_id]:stop()
+			end
+
 			active_spinner = Spinner:new(chat_id, args.buf)
-			spinners[chat_id] = active_spinner
+			if active_spinner then
+				spinners[chat_id] = active_spinner
+			else
+				log.error("Failed to create spinner for chat", chat_id)
+			end
 		end,
 	})
 
@@ -22,6 +35,11 @@ M.setup = function()
 		pattern = "CodeCompanionChatClosed",
 		callback = function(args)
 			log.debug("CodeCompanionChatClosed")
+			if not args or not args.data or not args.data.id then
+				log.warn("Invalid args in CodeCompanionChatClosed")
+				return
+			end
+
 			local chat_id = args.data.id
 			if spinners[chat_id] then
 				spinners[chat_id]:stop()
@@ -34,6 +52,11 @@ M.setup = function()
 		pattern = "CodeCompanionChatOpened",
 		callback = function(args)
 			log.debug("CodeCompanionChatOpened")
+
+			if not args or not args.data or not args.data.id then
+				log.warn("Invalid args in CodeCompanionChatOpened")
+				return
+			end
 
 			local spinner = spinners[args.data.id]
 
@@ -53,8 +76,17 @@ M.setup = function()
 		pattern = "CodeCompanionChatHidden",
 		callback = function(args)
 			log.debug("CodeCompanionChatHidden")
+			if not args or not args.data or not args.data.id then
+				log.warn("Invalid args in CodeCompanionChatHidden")
+				return
+			end
+
 			local spinner = spinners[args.data.id]
-			spinner:disable()
+			if spinner then
+				spinner:disable()
+			else
+				log.warn("No spinner found for chat", args.data.id)
+			end
 		end,
 	})
 
@@ -62,7 +94,16 @@ M.setup = function()
 		pattern = "CodeCompanionRequestStarted",
 		callback = function(args)
 			log.debug("CodeCompanionRequestStarted")
-			assert(active_spinner)
+			if not args or not args.data or not args.data.id then
+				log.warn("Invalid args in CodeCompanionRequestStarted")
+				return
+			end
+
+			if not active_spinner then
+				log.warn("No active spinner available")
+				return
+			end
+
 			active_spinner:start(args.data.id)
 		end,
 	})
@@ -72,12 +113,17 @@ M.setup = function()
 		callback = function(args)
 			log.debug("CodeCompanionRequestFinished")
 
+			if not args or not args.data or not args.data.id then
+				log.warn("Invalid args in CodeCompanionRequestFinished")
+				return
+			end
+
 			-- Search for the spinner is handling the request.
 			-- Note: If the chat was stopped, the spinner was deleted.
 			-- In that case, no spinner will be found.
 			local request_id = args.data.id
 			for _, spinner in pairs(spinners) do
-				if spinner.request_id == request_id then
+				if spinner and spinner.request_id == request_id then
 					spinner:stop()
 					break
 				end

--- a/lua/codecompanion-spinner/spinner-manager.lua
+++ b/lua/codecompanion-spinner/spinner-manager.lua
@@ -132,4 +132,19 @@ M.setup = function()
 	})
 end
 
+-- Cleanup function to safely stop all spinners
+M.cleanup = function()
+	for chat_id, spinner in pairs(spinners) do
+		if spinner then
+			local ok, err = pcall(spinner.stop, spinner)
+			if not ok then
+				log.error("Failed to stop spinner for chat", chat_id, ":", err)
+			end
+		end
+	end
+	spinners = {}
+	active_spinner = nil
+	log.debug("Spinner manager cleaned up")
+end
+
 return M


### PR DESCRIPTION
- document new spinner styles: "spinner", "fidget", "none"
- add configuration guide and troubleshooting in docs/configuration.md
- provide example configs for lazy.nvim and dynamic style switching
- update README and help docs with fidget integration and options
- clarify dependencies for each style

feat(core): support fidget.nvim integration and runtime style switching

- add fidget-spinner backend for progress notifications
- enable style selection: "spinner", "fidget", or "none"
- validate and handle invalid style options gracefully
- allow runtime switching by calling setup() with new style
- improve error handling and logging throughout spinner manager

fix(spinner): improve robustness and error handling

- validate buffer and chat_id in spinner creation
- handle invalid or missing request/chat data in autocommands
- prevent crashes if timer or extmarks fail to initialize
- ensure cleanup of timers and extmarks on stop/close

chore: update examples and documentation references

- add examples/lazy-config.lua and examples/different-configs.lua
- update links in help docs to new examples and configuration guide